### PR TITLE
Fix calcuations for staking gamma

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -24,6 +24,20 @@ type RewardHypervisorShare @entity {
   shares: BigInt!
 }
 
+type RewardHypervisorTx @entity {
+  id: ID!
+  timestamp: BigInt!
+  "stake or unstake"
+  action: String!
+  account: Account!
+  gammaAmount: BigInt!
+  xgammaAmount: BigInt!
+  xgammaAmountBefore: BigInt!
+  xgammaAmountAfter: BigInt!
+  xgammaSupplyBefore: BigInt!
+  xgammaSupplyAfter: BigInt!
+}
+
 type DistributionDayData @entity {
   id: ID!
   date: BigInt!

--- a/src/mappings/xgammaToken.ts
+++ b/src/mappings/xgammaToken.ts
@@ -8,37 +8,63 @@ import {
 	decreaseRewardHypervisorShares
 } from '../utils/rewardHypervisor'
 import { updateRewardHypervisorDayData } from '../utils/intervalUpdates'
+import { getOrCreateRewardHypervisorTx } from '../utils/entities'
 
 
 export function handleTransfer(event: TransferEvent): void {
 	let xgamma = getOrCreateRewardHypervisor()
+	let xgammaTx = getOrCreateRewardHypervisorTx(event.transaction.hash.toHex())
 	let shares = event.params.value
 
 	let ADDR_ZERO = Address.fromString(ADDRESS_ZERO)
+	let fromAddress = event.params.from.toHex()
+	let toAddress = event.params.to.toHex()
 	let mintEvent = (event.params.from == ADDR_ZERO)
 	let burnEvent = (event.params.to == ADDR_ZERO)
 
+	//  Track state of shares before transfer
+	let toShare = getOrCreateRewardHypervisorShare(toAddress)
+	let toSharesBefore = toShare.shares
+
+	let fromShare = getOrCreateRewardHypervisorShare(fromAddress)
+	let fromSharesBefore = fromShare.shares
+	
+	xgammaTx.timestamp = event.block.timestamp
+	xgammaTx.xgammaAmount = shares
+	xgammaTx.xgammaSupplyBefore = xgamma.totalSupply
+
+
 	if (mintEvent) {
 		// Mint shares
+		xgammaTx.action = "stake"
+		xgammaTx.account = toAddress
+		xgammaTx.xgammaAmountBefore = toSharesBefore
 		xgamma.totalSupply += shares
+		xgammaTx.xgammaSupplyAfter = xgamma.totalSupply
 	} else {
 		// Decrease shares of from account
-		decreaseRewardHypervisorShares(event.params.from.toHex(), shares)
+		decreaseRewardHypervisorShares(fromAddress, shares)
+		xgammaTx.xgammaAmountAfter = fromSharesBefore - shares
 	}
 	
 	if (burnEvent) {
 		// Burn shares
+		xgammaTx.action = "unstake"
+		xgammaTx.account = fromAddress
+		xgammaTx.xgammaAmountBefore = fromSharesBefore
 		xgamma.totalSupply -= shares
+		xgammaTx.xgammaSupplyAfter = xgamma.totalSupply 
 	} else {
 		// Increase shares of to account
-		let xgammaShare = getOrCreateRewardHypervisorShare(event.params.to.toHex())
-		xgammaShare.shares += shares
-		xgammaShare.save()
+		toShare.shares += shares
+		xgammaTx.xgammaAmountAfter = toSharesBefore + shares
+		toShare.save()
 	}
 	
 	xgamma.save()
 
 	if (mintEvent || burnEvent) {
+		xgammaTx.save()  // no need to save if not mint or burn
 		updateRewardHypervisorDayData(event.block.timestamp, TZ_UTC)
 		updateRewardHypervisorDayData(event.block.timestamp, TZ_EST)
 	}

--- a/src/utils/entities.ts
+++ b/src/utils/entities.ts
@@ -1,4 +1,5 @@
-import { User, Account, ProtocolDistribution } from "../../generated/schema"
+import { User, Account, ProtocolDistribution, RewardHypervisorTx } from "../../generated/schema"
+import { ZERO_BI } from "./constants"
 
 
 export function getOrCreateUser(addressString: string, saveOnCreate: boolean=false): User {
@@ -19,7 +20,7 @@ export function getOrCreateAccount(addressString: string, saveOnCreate: boolean=
 	let account = Account.load(addressString)
 	if (account == null) {
 		account = new Account(addressString)
-        account.type == "non visor"
+        account.type = "non-visor"
 		account.parent = addressString  // Default to self, update to visor owner if created from Visor Factory
 		
 		if (saveOnCreate) {
@@ -41,4 +42,26 @@ export function getOrCreateProtocolDistribution(
     }
 
     return protocolDist as ProtocolDistribution
+}
+
+
+export function getOrCreateRewardHypervisorTx(
+	txId: string
+): RewardHypervisorTx {
+	let tx = RewardHypervisorTx.load(txId)
+
+	if (!tx) {
+		tx = new RewardHypervisorTx(txId)
+		tx.timestamp = ZERO_BI
+		tx.action = ""
+		tx.account = ""
+		tx.gammaAmount = ZERO_BI
+		tx.xgammaAmount = ZERO_BI
+		tx.xgammaAmountBefore = ZERO_BI
+		tx.xgammaAmountAfter = ZERO_BI
+		tx.xgammaSupplyBefore = ZERO_BI
+		tx.xgammaSupplyAfter = ZERO_BI
+	}
+
+	return tx as RewardHypervisorTx
 }

--- a/src/utils/gammaToken.ts
+++ b/src/utils/gammaToken.ts
@@ -1,25 +1,21 @@
 /* eslint-disable prefer-const */
-import { BigInt } from "@graphprotocol/graph-ts";
 import { Account } from "../../generated/schema";
-import {
-  getOrCreateRewardHypervisor,
-  getOrCreateRewardHypervisorShare,
-} from "./rewardHypervisor";
+import { getOrCreateRewardHypervisorTx } from "./entities";
+import { getOrCreateRewardHypervisor } from "./rewardHypervisor";
 
 
 export function unstakeGammaFromAccount(
   accountAddress: string,
-  amount: BigInt
+  transactionId: string
 ): void {
   
   let xgamma = getOrCreateRewardHypervisor();
-  let xgammaShares = getOrCreateRewardHypervisorShare(accountAddress);
-
+  let xgammaTx = getOrCreateRewardHypervisorTx(transactionId);
+	
   let account = Account.load(accountAddress);
   if (account != null) {
-    let gammaStaked =
-      (xgammaShares.shares * xgamma.totalGamma) /
-      xgamma.totalSupply;
+    let amount = xgammaTx.gammaAmount
+    let gammaStaked = (xgammaTx.xgammaAmountBefore * xgamma.totalGamma) / xgammaTx.xgammaSupplyBefore;
     let gammaEarned = gammaStaked - account.gammaDeposited;
 
     if (amount > gammaEarned) {

--- a/src/utils/rewardHypervisor.ts
+++ b/src/utils/rewardHypervisor.ts
@@ -25,7 +25,7 @@ export function getOrCreateRewardHypervisorShare(accountAddress: string): Reward
 	let xgammaShare = RewardHypervisorShare.load(id)
 	if (!xgammaShare) {
 		let account = getOrCreateAccount(accountAddress, true)
-		if (account.type === 'non visor') {
+		if (account.type === 'non-visor') {
 			getOrCreateUser(account.parent, true)
 		}
 

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -27,6 +27,7 @@ dataSources:
         - Account
         - RewardHypervisor
         - RewardHypervisorShare
+        - RewardHypervisorTx
       abis:
         - name: ERC20
           file: ./abis/ERC20.json
@@ -52,6 +53,7 @@ dataSources:
       entities:
         - RewardHypervisor
         - RewardHypervisorShare
+        - RewardHypervisorTx
       abis:
         - name: ERC20
           file: ./abis/ERC20.json

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -19,6 +19,7 @@ dataSources:
         - Account
         - RewardHypervisor
         - RewardHypervisorShare
+        - RewardHypervisorTx
       abis:
         - name: ERC20
           file: ./abis/ERC20.json
@@ -42,6 +43,7 @@ dataSources:
       entities:
         - RewardHypervisor
         - RewardHypervisorShare
+        - RewardHypervisorTx
       abis:
         - name: ERC20
           file: ./abis/ERC20.json


### PR DESCRIPTION
In order to keep track of stats accurately, the state change needed to be tracked over two different events in the same transaction.
Add entity to do this.